### PR TITLE
Port Vue2 Dynamic Component syntax to Svelte:Element

### DIFF
--- a/src/lib/scrollactive.svelte
+++ b/src/lib/scrollactive.svelte
@@ -361,6 +361,6 @@
 	}
 </script>
 
-<component :is="tag" id="scrollactive-nav-wrapper" class="scrollactive-nav">
-	<slot />
-</component>
+<svelte:element this={tag} id="scrollactive-nav-wrapper" class="scrollactive-nav">
+  <slot />
+</svelte:element>

--- a/src/lib/scrollactive.svelte
+++ b/src/lib/scrollactive.svelte
@@ -362,5 +362,5 @@
 </script>
 
 <svelte:element this={tag} id="scrollactive-nav-wrapper" class="scrollactive-nav">
-  <slot />
+	<slot />
 </svelte:element>


### PR DESCRIPTION
This PR Addresses [Issue #1](https://github.com/dmvvilela/svelte-scrollactive/issues/1)

After the update, the custom element successfully becomes a `<nav id="scrollactive-nav-wrapper" class="scrollactive-nav">`element based on the tag being assigned `nav` on line 93.